### PR TITLE
Migrate CertificateSigningRequest to k8s version v1.19+

### DIFF
--- a/create-user.sh
+++ b/create-user.sh
@@ -13,7 +13,7 @@ openssl req -new -newkey rsa:4096 -nodes -keyout $USERNAME-k8s.key -out $USERNAM
 echo "upload CSR to Kubernetes"
 
 cat <<EOT | kubectl apply -f -
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: $USERNAME-k8s-access
@@ -21,6 +21,7 @@ spec:
   groups:
   - system:authenticated
   request: $( cat $USERNAME-k8s.csr | base64 | tr -d '\n' )
+  signerName: kubernetes.io/kube-apiserver-client
   usages:
   - client auth
 EOT


### PR DESCRIPTION
Hi there,

first of all, thanks for providing these scripts! They work perfectly. One thing caught my attention, though: I noticed a warning when creating the user on Kubernetes v1.21. It seems like the certification API was officially moved to v1 starting in v1.19. In the upcoming k8s version (1.22) the "old" API will be removed and therefore not be usable anymore. 

The changes in this pull request are compatible with the current stable v1 API and use the required format of the CertificateSigningRequest. This is necessary in order to stay compatible with newer K8S versions.

Side note: Since I don't have to worry about older K8S versions at this point, I didn't add an option to switch between the two APIs, but I do realize that there may be people out there needing the "old" API for now. Let me know if your use case is based on a pre-v1.19 K8S version. In that case it may be worth adding an extra parameter to the script for now. However, if this is not needed its probably cleaner without an extra parameter.

Cheers,
Ben